### PR TITLE
Add GNOME Shell 50 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "wifi-signal-plus@jalil.arfaoui.net",
     "name": "WiFi Signal Plus",
     "description": "Displays WiFi generation (4/5/6/7) in the top bar with detailed connection info on hover",
-    "shell-version": ["45", "46", "47", "48", "49"],
+    "shell-version": ["45", "46", "47", "48", "49", "50"],
     "version": 7,
     "url": "https://github.com/JalilArfaoui/gnome-extension-wifi-signal-plus",
     "donations": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -272,7 +272,7 @@ export default class WifiSignalPlusExtension extends Extension {
         item.add_style_class_name('wifi-connection-header');
 
         const leftBox = new St.BoxLayout({
-            vertical: true,
+            orientation: Clutter.Orientation.VERTICAL,
             x_expand: true,
             y_align: Clutter.ActorAlign.CENTER,
         });
@@ -333,7 +333,7 @@ export default class WifiSignalPlusExtension extends Extension {
 
         let barFill: St.Widget | undefined;
         if (withBar) {
-            const box = new St.BoxLayout({ vertical: true, x_expand: true });
+            const box = new St.BoxLayout({ orientation: Clutter.Orientation.VERTICAL, x_expand: true });
 
             const row = new St.BoxLayout({ x_expand: true });
             row.add_child(labelWidget);
@@ -773,7 +773,7 @@ export default class WifiSignalPlusExtension extends Extension {
         const metricsBox = this.createCardMetrics(bestAp, apCount);
         headerBox.add_child(metricsBox);
 
-        const outerBox = new St.BoxLayout({ vertical: true, x_expand: true });
+        const outerBox = new St.BoxLayout({ orientation: Clutter.Orientation.VERTICAL, x_expand: true });
         outerBox.add_child(headerBox);
 
         const quality = getSignalQualityFromPercent(bestAp.signalPercent);
@@ -856,7 +856,7 @@ export default class WifiSignalPlusExtension extends Extension {
             item.add_child(spacer);
         }
 
-        const outerBox = new St.BoxLayout({ vertical: true, x_expand: true });
+        const outerBox = new St.BoxLayout({ orientation: Clutter.Orientation.VERTICAL, x_expand: true });
 
         // Info row: generation + BSSID + details + signal%
         const infoRow = new St.BoxLayout({ x_expand: true });


### PR DESCRIPTION
Fixes #6

## Summary

- Add `"50"` to `shell-version` in `metadata.json` so the extension is recognized on GNOME Shell 50
- Replace deprecated `vertical: true` with `orientation: Clutter.Orientation.VERTICAL` in all `St.BoxLayout` constructors — the `vertical` property was removed in GNOME Shell 50

🤖 Generated with [Claude Code](https://claude.ai/claude-code)